### PR TITLE
TestSetterAndGetter: Allow specifying an expected value

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [License](#license)
+- [Installation](#Installation)
+- [Usage](#Usage)
+- [License](#License)
 
 <!-- /TOC -->
 

--- a/test/TestUtilsTest/TestCase/TestSetterAndGetterTraitTest.php
+++ b/test/TestUtilsTest/TestCase/TestSetterAndGetterTraitTest.php
@@ -113,6 +113,10 @@ class TestSetterAndGetterTraitTest extends TestCase
                 ['setter_value' => '__SELF__'],
                 ['setter_value' => '__TARGET__']
             ],
+            [
+                ['value' => 'value', 'expect' => 'expect'],
+                ['value' => 'value', 'expect' => 'expect'],
+            ],
 
             [
                 [
@@ -134,10 +138,12 @@ class TestSetterAndGetterTraitTest extends TestCase
                 [
                     'value_object' => \stdClass::class,
                     'setter_value_object' => [\stdClass::class, ['arg']],
+                    'expect_object' => \stdClass::class,
                 ],
                 [
                     'value' => new \stdClass,
                     'setter_value' => new \stdClass,
+                    'expect' => new \stdClass,
                 ]
             ],
 
@@ -153,7 +159,7 @@ class TestSetterAndGetterTraitTest extends TestCase
 
             [
                 ['value_callback' => 'unallable'],
-                'Invalid value callback',
+                'Invalid callback',
             ],
 
             [
@@ -162,8 +168,13 @@ class TestSetterAndGetterTraitTest extends TestCase
             ],
 
             [
+                ['expect_callback' => function() { return 'calledback'; }],
+                ['expect' => 'calledback']
+            ],
+
+            [
                 ['assert' => [$this, 'uncallable']],
-                'Invalid assert callback'
+                'Invalid callback'
             ],
             [
                 ['nonexistent' => 'papp'],
@@ -350,5 +361,25 @@ class TestSetterAndGetterTraitTest extends TestCase
 
         static::assertEquals(['value'], $trait->target->called['setprop'][0]);
         static::assertEquals(['value', 'value'], $trait->target->called['assert'][0]);
+    }
+
+    public function testExpectedValueWillBePassedToGetterAssertion()
+    {
+        $trait = $this->getConcreteTrait();
+
+        $trait->target->return['getprop'][] = 'modifiedValueFromGetter';
+
+        $assertVars = [];
+        $spec = [
+            'value' => 'value',
+            'expect' => 'modifiedValue',
+            'assert' => function($expect, $actual) use (&$assertVars) {
+                $assertVars = [$expect, $actual];
+            }
+        ];
+
+        $trait->testSetterAndGetter('prop', $spec);
+
+        static::assertEquals(['modifiedValue', 'modifiedValueFromGetter'], $assertVars);
     }
 }


### PR DESCRIPTION
There might be classes that define a setter (or getter) method  which modifies the property value prior to returning it. To be able to test this behaviour, this PR adds the 'expect', 'expect_object' and 'expect_callback' keys to the specification.

