### PR TITLE
Improve development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ test export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
 phpunit.xml* export-ignore
+phpcs.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,9 @@
-# Text-Editor backup files
-*~
-
 # ignore dependencies
 vendor
 
 # ignore test/coverage reports
 test/coverage
+coverage.clover.xml
 
 # ignore phpunit cache
 .phpunit.result.cache
-
-# Ignore IDEs
-.idea
-.atom

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,21 @@
     }
   },
   "scripts": {
-    "test": "vendor/bin/phpunit"
+    "test": "vendor/bin/phpunit",
+    "test-coverage-clover": "vendor/bin/phpunit --coverage-clover=coverage.clover.xml",
+    "test-coverage-html": "vendor/bin/phpunit --coverage-html=test/coverage",
+    "lint": "vendor/bin/phpcs --standard=phpcs.xml src/*"
+  },
+  "scripts-descriptions": {
+    "test": "Runs the phpunit testsuite",
+    "test-coverage-clover": "Runs the phpunit testsuite and generates coverage in the clover format in the file 'coverage.clover.xml'",
+    "test-coverage-html": "Runs the phpunit testsuite and generates coverage in html format in the directory 'test/coverage'.",
+    "lint": "Runs PHP_CodeSniffer on 'src/*'"
   },
   "require-dev": {
     "php-mock/php-mock-prophecy": "^0.0.2",
-    "psr/container": "^1.0"
+    "psr/container": "^1.0",
+    "squizlabs/php_codesniffer": ">=3.4 <3.5.0",
+    "slevomat/coding-standard": "^5.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8af053acee3e798b91d256ebb574e2c0",
+    "content-hash": "e5ca401bbe9d022e113dfa9beb709b06",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1651,6 +1651,53 @@
             "time": "2016-05-13T12:02:19+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/8c4ef2aefd9788238897b678a985e1d5c8df6db4",
+                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan": "^0.10",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2",
+                "symfony/process": "^3.4 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "time": "2019-06-07T19:13:52+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -1698,6 +1745,97 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "287ac3347c47918c0bf5e10335e36197ea10894c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/287ac3347c47918c0bf5e10335e36197ea10894c",
+                "reference": "287ac3347c47918c0bf5e10335e36197ea10894c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpstan/phpdoc-parser": "^0.3.1",
+                "squizlabs/php_codesniffer": "^3.4.1"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "phing/phing": "2.16.1",
+                "phpstan/phpstan": "0.11.4",
+                "phpstan/phpstan-phpunit": "0.11",
+                "phpstan/phpstan-strict-rules": "0.11",
+                "phpunit/phpunit": "8.0.5"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2019-03-22T19:10:53+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-04-10T23:49:02+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="cross-phpunit-utils-standard">
+  <config name="installed_paths" value="../../slevomat/coding-standard"/>
+  <exclude-pattern>**/test/*</exclude-pattern>
+  <exclude-pattern>**/vendor/*</exclude-pattern>
+
+
+  <rule ref="PSR2">
+  	<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.Indent" />
+  </rule>
+  <rule ref="PSR12"/>
+  <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+          <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="2" />
+            <property name="newlinesCountAfterDeclare" value="2" />
+            <property name="spacesCountAroundEqualsSign" value="0" />
+          </properties>
+        </rule>
+        <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation" />
+        <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
+          <properties>
+            <property name="alwaysUsedPropertiesAnnotations" type="array">
+              <element value="@ODM\" />
+            </property>
+          </properties>
+        </rule>
+        <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
+        <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
+        <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+          <properties>
+            <property name="searchAnnotations" value="true" />
+          </properties>
+        </rule>
+        <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace" />
+        <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias" />
+        <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+          <properties>
+            <property name="caseSensitive" value="true" />
+          </properties>
+        </rule>
+        <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration" />
+        <rule ref="SlevomatCodingStandard.Variables.UnusedVariable" />
+        <rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
+        <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
+        <rule ref="SlevomatCodingStandard.PHP.TypeCast" />
+        <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
+          <properties>
+            <property name="spacesCountBeforeColon" value="0" />
+          </properties>
+        </rule>
+        <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+</ruleset>


### PR DESCRIPTION
 * Require squizlab/php_codesniffer and additional
   slevomat/coding-standard

 * Define a phpcs standard in phpcs.xml

 * Adds composer script to run test (with coverage) and
   lint (phpcs) the src directory

 * Optimizes .gitignore and .gitattributes