### PR TITLE
TestSetterAndGetterTrait: Allow setting target per individual test

### DIFF
--- a/src/TestCase/TestSetterAndGetterTrait.php
+++ b/src/TestCase/TestSetterAndGetterTrait.php
@@ -190,7 +190,8 @@ trait TestSetterAndGetterTrait
 
         if (isset($spec['target_callback'])) {
             $cb = $spec['target_callback'];
-            if (is_string($cb)) {
+
+            if (is_string($cb) && !is_callable($cb)) {
                 $cb = [$this, $cb];
             }
 

--- a/src/TestCase/TestSetterAndGetterTrait.php
+++ b/src/TestCase/TestSetterAndGetterTrait.php
@@ -298,7 +298,7 @@ trait TestSetterAndGetterTrait
                 case 'value_callback':
                 case 'setter_value_callback':
                 case 'expect_callback':
-                    if (is_string($value)) {
+                    if (is_string($value) && !is_callable($value)) {
                         $value = [$this, $value];
                     }
 

--- a/src/TestCase/TestSetterAndGetterTrait.php
+++ b/src/TestCase/TestSetterAndGetterTrait.php
@@ -198,10 +198,8 @@ trait TestSetterAndGetterTrait
             return $normalized;
         }
 
-        $err = __TRAIT__ . ': ' . get_class($this) . ': ';
-
         if (!is_array($spec)) {
-            throw new \PHPUnit\Framework\Exception($err . 'Invalid specification. Must be array.');
+            throw InvalidUsageException::fromTrait(__TRAIT__, __CLASS__, 'Invalid specification. Must be array.');
         }
 
         foreach ($spec as $key => $value) {
@@ -258,7 +256,11 @@ trait TestSetterAndGetterTrait
                     }
 
                     if (!is_callable($value)) {
-                        throw new \PHPUnit\Framework\Exception($err . 'Invalid callback for "' . $key . '".');
+                        throw InvalidUsageException::fromTrait(
+                            __TRAIT__,
+                            __CLASS__,
+                            'Invalid callback for "' . $key . '".'
+                        );
                     }
 
                     $key = substr($key, 0, -9);
@@ -277,7 +279,11 @@ trait TestSetterAndGetterTrait
                     }
 
                     if (!is_callable($value)) {
-                        throw new \PHPUnit\Framework\Exception($err . 'Invalid callback for "' . $key . '".');
+                        throw InvalidUsageException::fromTrait(
+                            __TRAIT__,
+                            __CLASS__,
+                            'Invalid callback for "' . $key . '".'
+                        );
                     }
 
                     break;

--- a/src/TestCase/TestSetterAndGetterTrait.php
+++ b/src/TestCase/TestSetterAndGetterTrait.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * CROSS PHPUnit Utils
  *
@@ -6,6 +6,8 @@
  * @license    MIT
  * @copyright  2019 Cross Solution <http://cross-solution.de>
  */
+
+declare(strict_types=1);
 
 namespace Cross\TestUtils\TestCase;
 


### PR DESCRIPTION
This feature let's you use a different SUT for an individual test.

``` php
public function setterAndGetterData()
{
   private $target = SubjectUnderTest::class;

    return [
        ['id', 'someTestId'],
        ['test', [
            'target' => SpecialSubjectUnderTest::class,
            'value' => 'test',
        ]],
    ];
}
```

Also: The trait throws only InvalidUsageExceptions.