### PR TITLE
Fix setting expected values in TestSetterAndGetterTrait

### DIFF
--- a/src/TestCase/TestSetterAndGetterTrait.php
+++ b/src/TestCase/TestSetterAndGetterTrait.php
@@ -154,7 +154,7 @@ trait TestSetterAndGetterTrait
             [$setter, $setterArgs] = $spec['setter'];
             $setterValue = $target->$setter($value, ...$setterArgs);
 
-            if ('__SETTER_AND_GETTER__' != $spec['setter_value']) {
+            if ($spec['setter_value'] !== '__SETTER_AND_GETTER__') {
                 $spec['setter_assert']($spec['setter_value'], $setterValue);
             }
         }
@@ -163,7 +163,7 @@ trait TestSetterAndGetterTrait
             [$getter, $getterArgs] = $spec['getter'];
             $getterValue = $target->$getter(...$getterArgs);
 
-            if ($spec['expect'] != '__SETTER_AND_GETTER__') {
+            if ($spec['expect'] !== '__SETTER_AND_GETTER__') {
                 $value = $spec['expect'];
             }
 
@@ -210,7 +210,7 @@ trait TestSetterAndGetterTrait
                     break;
 
                 case 'setter_value':
-                    if ('__SELF__' == $value) {
+                    if ('__SELF__' === $value) {
                         $value = $target;
                         if (!isset($spec['setter_assert'])) {
                             $normalized['setter_assert'] = [static::class, 'assertSame'];

--- a/test/TestUtilsTest/TestCase/TestSetterAndGetterTrait/SpecifyExpectedValueTest.php
+++ b/test/TestUtilsTest/TestCase/TestSetterAndGetterTrait/SpecifyExpectedValueTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * phpunit-utils
+ *
+ * @filesource
+ * @copyright 2020 CROSS Solution <https://www.cross-solution.de>
+ * @license MIT
+ */
+
+declare(strict_types=1);
+namespace Cross\TestUtilsTest\TestCase\TestSetterAndGetterTrait;
+
+use PHPUnit\Framework\TestCase;
+use Cross\TestUtils\TestCase\TestSetterAndGetterTrait;
+
+/**
+ * Testcase for \Cross\TestUtils\TestCase\TestSetterAndGetterTrait
+ *
+ * @covers \Cross\TestUtils\TestCase\TestSetterAndGetterTrait
+ * @author Mathias Gelhausen <gelhausen@cross-solution.de>
+ * @group Cross.TestUtils
+ * @group Cross.TestUtils.TestCase
+ * @group Cross.TestUtils.TestCase.TestSetterAndGetterTrait
+ */
+class SpecifyExpectedValueTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $dummy = new class
+        {
+            public $attr;
+            public $expect = 'expected';
+
+            public function setAttr($v)
+            {
+                $this->attr = $v;
+                return $this->expect;
+            }
+
+            public function getAttr()
+            {
+                return $this->expect;
+            }
+        };
+
+        $this->target = new class($dummy)
+        {
+            use TestSetterAndGetterTrait;
+
+            public $target;
+            public $testSetterAndGetter;
+            public static $result;
+
+            public function __construct($dummy)
+            {
+                $this->target = $dummy;
+                static::$result = null;
+            }
+
+            public static function assertEquals($expect)
+            {
+                static::$result = $expect;
+            }
+
+            public static function assertSame($expect)
+            {
+                static::$result = $expect;
+            }
+        };
+    }
+
+    /**
+     * @testWith    [true, "a string"]
+     *              [true, [1,2,3]]
+     *              [true, "stdClass", "object"]
+     *
+     */
+    public function testSpecifyingExpectedGetterValues($expect, $value, $type = null)
+    {
+        $this->target->target->expect = $expect;
+        $this->target->testSetterAndGetter(
+            'attr',
+            ['value' . ($type ? "_$type" : '') => $value, 'expect' => $expect]
+        );
+
+        static::assertEquals($expect, $this->target::$result);
+    }
+
+    /**
+     * @testWith    [true]
+     */
+    public function testSpecifiyingExpectedSetterValues($expect, $type = null)
+    {
+        if ($type === 'object') {
+            $expect = new $expect();
+        }
+        $this->target->target->expect = $expect;
+        $this->target->testSetterAndGetter(
+            'attr',
+            ['getter' => false, 'value' => 'irrelevant', 'setter_value' => $expect]
+        );
+
+        static::assertEquals($expect, $this->target::$result);
+    }
+}


### PR DESCRIPTION
Fix #5

* Creates TestCase for unwanted behaviour.
* Makes the  comparisons strict, so types are not casted automatically.



