### PR TITLE
refactor(TestSetterAndGetterTrait): Do not automatically set 'assert' to 'same' if value is an object

### DIFF
--- a/src/TestCase/TestSetterAndGetterTrait.php
+++ b/src/TestCase/TestSetterAndGetterTrait.php
@@ -259,9 +259,6 @@ trait TestSetterAndGetterTrait
                 case 'setter_value':
                     if ('__SELF__' === $value) {
                         $value = $target;
-                        if (!isset($spec['setter_assert'])) {
-                            $normalized['setter_assert'] = [static::class, 'assertSame'];
-                        }
                     }
                     break;
 
@@ -288,13 +285,6 @@ trait TestSetterAndGetterTrait
                     $args  = $value[1] ?? [];
                     $key = substr($key, 0, -7);
                     $value = new $class(...$args);
-
-                    $assertKey = str_replace('value', 'assert', $key);
-
-                    if (!isset($spec[$assertKey]) && array_key_exists($assertKey, $normalized)) {
-                        $normalized[$assertKey] = [static::class, 'assertSame'];
-                    }
-
                     break;
 
                 case 'value_callback':


### PR DESCRIPTION
It was impossible to check a object values for equality without specifying the 'assert' method.
This could have been unintuitive in certain test situations - while the opposite case ( check value objects to be
the exact same) had not to be made explicit.

Now checking if two value objects are the same has to be made explicit by specifying the assert method.