### PR TITLE
fix: remove usage of deprecated string offset access syntax

### DIFF
--- a/src/TestCase/SetupTargetTrait.php
+++ b/src/TestCase/SetupTargetTrait.php
@@ -127,7 +127,7 @@ trait SetupTargetTrait
         $nameParts = explode(' ', $this->getName());
         $name      = reset($nameParts);
         $set       = end($nameParts);
-        $set       = '#' == $set{0} || '"' == $set{0} ? trim($set, '"') : '';
+        $set       = '#' == $set[0] || '"' == $set[0] ? trim($set, '"') : '';
 
         foreach ($specs as $spec) {
             $for = isset($spec['for']) ? (array) $spec['for'] : ['*'];

--- a/src/Utils/Instance.php
+++ b/src/Utils/Instance.php
@@ -74,7 +74,7 @@ final class Instance
             );
         }
 
-        if ('!' == $fqcn{0}) {
+        if ('!' == $fqcn[0]) {
             return self::reflection(substr($fqcn, 1));
         }
 
@@ -142,7 +142,7 @@ final class Instance
                     break;
 
                 // '@function'
-                case is_string($value) && '@' == $value{0}:
+                case is_string($value) && '@' == $value[0]:
                     $callback = ltrim($value, '@');
                     break;
 

--- a/src/Utils/Target.php
+++ b/src/Utils/Target.php
@@ -68,7 +68,7 @@ final class Target
                 return $target;
             }
 
-            if (!$forceObject && is_string($target) && '!' != $target{0}) {
+            if (!$forceObject && is_string($target) && '!' != $target[0]) {
                 return $target;
             }
 


### PR DESCRIPTION
In three files, the string offset access syntax with curly braces was used,
which causes errors when executed under PHP 7.4.

[ fixes #8 ]